### PR TITLE
Fix typo in second test (line 13) requirement.

### DIFF
--- a/spec/icebreakers_homepage_with_css_spec.rb
+++ b/spec/icebreakers_homepage_with_css_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "A Styled IceBreakers Homepage" do
   end
 
   context 'General' do
-    it 'has a global selector to set font-family of "Helvetica", "Arial", "san-serif"' do
+    it 'has a global selector to set font-family of "Helvetica", "Arial", "sans-serif"' do
       css = parse_css_from_file("./style.css")
       global = css["*"]
 


### PR DESCRIPTION
Second test (line 13) asks for improper font family of `san-serif` instead of `sans-serif`. I submitted a pull request to edit the README.md as appropriate to fix this issue.